### PR TITLE
Update Bedrodium to 1.18.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,10 @@
 plugins {
-    id 'fabric-loom' version '0.9-SNAPSHOT'
+    id 'fabric-loom' version '0.11-SNAPSHOT'
     id 'maven-publish'
 }
 
-sourceCompatibility = "16"
-targetCompatibility = "16"
+sourceCompatibility = "17"
+targetCompatibility = "17"
 
 version = project.mod_version
 group = project.maven_group
@@ -36,7 +36,7 @@ processResources {
     }
 }
 
-def targetJavaVersion = 16
+def targetJavaVersion = 17
 tasks.withType(JavaCompile).configureEach {
     it.options.encoding = "UTF-8"
     if (targetJavaVersion >= 10 || JavaVersion.current().isJava10Compatible()) {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/me/kirillirik/bedrodium/mixin/BlockOcclusionCacheMixin.java
+++ b/src/main/java/me/kirillirik/bedrodium/mixin/BlockOcclusionCacheMixin.java
@@ -17,7 +17,7 @@ public class BlockOcclusionCacheMixin {
     @Inject(method = "shouldDrawSide", at = @At("RETURN"), cancellable = true)
     public void shouldDrawSide(BlockState selfState, BlockView view, BlockPos pos, Direction facing, CallbackInfoReturnable<Boolean> cir) {
         if (!Bedrodium.passSide) return;
-        if (pos.getY() != 0 || facing != Direction.DOWN) return;
+        if (pos.getY() != -64 || facing != Direction.DOWN) return;
         cir.setReturnValue(false);
     }
 }

--- a/src/main/resources/bedrodium.mixins.json
+++ b/src/main/resources/bedrodium.mixins.json
@@ -2,7 +2,7 @@
   "required": true,
   "minVersion": "0.8",
   "package": "me.kirillirik.bedrodium.mixin",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "mixins": [
     "BlockOcclusionCacheMixin"
   ],

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -3,7 +3,7 @@
   "id": "bedrodium",
   "version": "${version}",
   "name": "Bedrodium",
-  "description": "Optimization of the 0th layer of the bedrock",
+  "description": "Optimization of the -64th layer of the bedrock",
   "authors": [
     "kirillirik"
   ],
@@ -22,7 +22,7 @@
   "depends": {
     "fabricloader": ">=0.11.6",
     "fabric": "*",
-    "minecraft": "1.17.1"
+    "minecraft": ">=1.17.1"
   },
   "custom": {
     "modmenu": {


### PR DESCRIPTION
### 1.18 modified the bedrock layer from 0 to -64, resulting in "holes" when you were facing down a block at layer 0.
![It doesn't draw the down side](https://i.ibb.co/tqpBvNw/2022-04-20-00-46-48.png)

### The fix is pretty simple; we just need to modify the condition `pos.getY() != 0` to `pos.getY() != -64` and voila.
![Yay, no more strange holes when mining!](https://i.ibb.co/zb8XLMb/2022-04-20-00-50-03.png)
![It now works at the correct layer](https://i.ibb.co/xCVX5Ng/2022-04-20-00-50-30.png)

Closes #4 